### PR TITLE
fix: Dark mode icon switching issue

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -865,14 +865,12 @@ details[open] .suggested-header::before {
     transform: rotate(0deg);
 }
 
-[data-theme="dark"] .theme-toggle .sun-icon,
-:root .theme-toggle .sun-icon {
+[data-theme="dark"] .theme-toggle .sun-icon {
     opacity: 1;
     transform: rotate(0deg);
 }
 
-[data-theme="dark"] .theme-toggle .moon-icon,
-:root .theme-toggle .moon-icon {
+[data-theme="dark"] .theme-toggle .moon-icon {
     opacity: 0;
     transform: rotate(-180deg);
 }


### PR DESCRIPTION
Fixes #2

## Summary
- Fixed CSS specificity conflict preventing moon icon from appearing in light mode
- Removed `:root` selectors that were overriding `[data-theme="light"]` rules
- Theme toggle now properly shows moon icon after switching to light mode

## Test Plan
- [ ] Start in dark mode (should show sun icon)
- [ ] Click sun icon to switch to light mode
- [ ] Verify moon icon appears in light mode
- [ ] Click moon icon to switch back to dark mode
- [ ] Verify sun icon appears in dark mode

Generated with [Claude Code](https://claude.ai/code)